### PR TITLE
Фильтр сообщений бота #13

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -130,6 +130,7 @@ func export() {
 		InputRoot:    opts.LogsPath,
 		OutputRoot:   opts.ExportPath,
 		TemplateFile: opts.TemplateFile,
+		BotUsername:  botUser.UserName,
 		SuperUsers:   opts.SuperUsers,
 		BroadcastUsers: events.SuperUser(
 			append(

--- a/app/reporter/export.go
+++ b/app/reporter/export.go
@@ -32,6 +32,7 @@ type ExporterParams struct {
 	OutputRoot     string
 	InputRoot      string
 	TemplateFile   string
+	BotUsername    string
 	SuperUsers     SuperUser
 	BroadcastUsers SuperUser // Users who can send "bot.MsgBroadcastStarted" and "bot.MsgBroadcastStarted" messages.
 	// it maybe just bot, or bot + some or all SuperUsers.
@@ -100,8 +101,9 @@ func (e *Exporter) toHTML(messages []bot.Message, num int) string {
 
 	type Record struct {
 		Time   string
-		IsHost bool
 		Msg    bot.Message
+		IsHost bool
+		IsBot  bool
 	}
 
 	type Data struct {
@@ -119,8 +121,9 @@ func (e *Exporter) toHTML(messages []bot.Message, num int) string {
 			data.Records,
 			Record{
 				Time:   msg.Sent.In(e.location).Format("15:04:05"),
-				IsHost: e.SuperUsers.IsSuper(msg.From.Username),
 				Msg:    msg,
+				IsHost: e.SuperUsers.IsSuper(msg.From.Username),
+				IsBot:  msg.From.Username == e.BotUsername,
 			},
 		)
 	}

--- a/data/logs.html
+++ b/data/logs.html
@@ -73,14 +73,9 @@
 
         <table class="table table-striped table-hover table-condensed" id="table">
         {{ range .Records }}
-        <tr>
-            {{- if .IsHost }}
-                <td class="danger" align="left">{{ .Msg.Sent | timestampHuman }}</td>
-                <td class="success" align="left"><span title="{{ .Msg.From.Username }}">{{ .Msg.From.DisplayName }}</span></td>
-            {{ else }}
-                <td class="success" align="left">{{ .Msg.Sent | timestampHuman }}</td>
-                <td class="success" align="left"><span title="{{ .Msg.From.Username }}">{{ .Msg.From.DisplayName }}</span></td>
-            {{ end -}}
+        <tr class="{{ if .IsHost }}host{{ else }}{{ if .IsBot }}bot{{ end }}{{ end }}">
+            <td class="{{ if .IsHost }}danger{{ else }}success{{ end }}" align="left">{{ .Msg.Sent | timestampHuman }}</td>
+            <td class="success" align="left"><span title="{{ .Msg.From.Username }}">{{ .Msg.From.DisplayName }}</span></td>
             <td class="warning" align="left">
                 {{- format .Msg.Text .Msg.Entities }}
                 {{- if .Msg.Image }}
@@ -105,7 +100,7 @@
                         value: 0,
                         classname: 'host',
                         style: '.table tr { display: none; } .table tr.host { display: table-row; }',
-                        detect: function(row) { return row.getElementsByClassName('danger').length > 0; }
+                        detect: function(row) { return row.getElementsByClassName('host').length > 0; }
                     },
                     link: {
                         value: 0,
@@ -117,7 +112,7 @@
                         value: 0,
                         classname: 'bot',
                         style: '.table tr.bot { display: none; }',
-                        detect: function(row) { return row.children[1].textContent == 'радио-т бот' && row.children[2].textContent.indexOf('==> ') == -1; }
+                        detect: function(row) { return row.getElementsByClassName('bot').length > 0; }
                     }
                 };
                 var filtersInited = false;


### PR DESCRIPTION
Этот PR исправляет #13: фильтр "убрать сообщения ботов".

Раньше отфильтровывались только сообщения начинающиеся на `==> ` от бота с ником `радио-т бот`. Теперь – все сообщения от бота, которому соответствует переданный в приложение токен.

Перепроверил фильтр "оставить сообщения ведущих" – работает.